### PR TITLE
Improve Docker configuration and PNG rendering quality

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,9 +1,10 @@
 services:
   foxhole-dashboard:
     build: .
-    container_name: foxhole-dashboard
+    container_name: foxhole-dashboard-dev
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
-      - "3000:3000"
+      - "3001:3000"
     volumes:
       - ./output:/app/output
       - ./data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   foxhole-dashboard:
     image: ghcr.io/stedrow/foxhole-dashboard:1.0.5
     container_name: foxhole-dashboard
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "0.0.0.0:3000:3000"
     volumes:

--- a/src/png-generator.js
+++ b/src/png-generator.js
@@ -20,10 +20,11 @@ class PNGGenerator {
       }
       const svg = this.svgGenerator.generateEpaperSVG();
 
-      // Convert SVG to PNG using resvg at native resolution
-      // This preserves all detail from the SVG (800x480)
+      // Convert SVG to PNG using resvg at 4x resolution for supersampling
+      // Higher resolution (3200x1920) allows downscaling to produce thinner, smoother lines
       const resvg = new Resvg(svg, {
-        dpi: 96, // Standard DPI for accurate rendering
+        fitTo: { mode: 'zoom', value: 4 }, // 4x zoom for 4x resolution (3200x1920)
+        dpi: 96, // Standard DPI
         shapeRendering: 2, // GeometricPrecision for crisp edges
         textRendering: 2, // GeometricPrecision for sharp text
         imageRendering: 1, // OptimizeQuality for best quality


### PR DESCRIPTION
## Summary
- Add user/group ID mapping to Docker Compose files to prevent permission issues with mounted volumes
- Update dev container name to `foxhole-dashboard-dev` and port to 3001 to avoid conflicts with production
- Increase PNG rendering resolution to 4x for supersampling, producing smoother and thinner lines

## Test plan
- [ ] Verify Docker containers start successfully with proper file permissions
- [ ] Test that generated PNG files have improved line quality
- [ ] Confirm dev and prod environments don't conflict when running simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)